### PR TITLE
fix: remove the CCPS placement coordinator role

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,7 +388,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
     <div class="about-copy reveal d1">
       <p class="first">Second year at IIT Bhilai, studying Data Science &amp; AI. I got into this field the normal way: built things, broke things, then realised the actual job is keeping things alive <strong>in production</strong>. Now I build AI systems end to end: agents, automations, data pipelines, and the 2am debugging sessions nobody posts about.</p>
       <p>By day I ship client-facing systems at <strong>Altagic</strong>. By night I maintain <strong>diffprompt</strong>, contribute to open source AI tooling, and queue Valorant with the boys. Everything I build gets stress-tested before it ships, because I’d rather break it than let a user do it.</p>
-      <p>I coordinate placements for 200+ students at CCPS, lead the AI/ML domain at OpenLake, and hold the strong opinion that DSA grind scores tell you almost nothing about whether someone can actually build.</p>
+      <p>I lead the AI/ML domain at OpenLake and hold the strong opinion that DSA grind scores tell you almost nothing about whether someone can actually build.</p>
     </div>
     <div class="photo-stack reveal d2">
       <div class="polaroid"><img src="img/me-apple.jpg" alt="Rudra at an Apple Store" onerror="this.parentElement.style.display='none'"/><div class="pcap">STRESS-TESTING A MAC PRO I CANNOT AFFORD (YET)</div></div>
@@ -487,8 +487,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
     <div class="sec-head reveal"><h2 class="sec-title">Experience <em>&amp; responsibility</em></h2><span class="label">QUESTS, MAIN AND SIDE</span></div>
     <div class="xp-list">
       <div class="xp reveal" data-detail="xp-altagic"><div class="org">Altagic<small>AI Automations Intern</small></div><div class="what">Building production automation systems: agentic workflows, AI-in-the-loop pipelines, internal tooling. Stack: n8n, WhatsApp Business API, Claude, CloseBot. <span class="nda">[ specifics under NDA ]</span></div><div class="when">MAY 2026 → NOW</div></div>
-      <div class="xp reveal d1" data-detail="xp-ccps"><div class="org">CCPS, IIT Bhilai<small>Placement Coordinator</small></div><div class="what">Coordinating placements for 200+ students across 30+ companies. Equal parts logistics, diplomacy, and crisis management at scale.</div><div class="when">2025 → NOW</div></div>
-      <div class="xp reveal d2" data-detail="xp-openlake"><div class="org">OpenLake, IIT Bhilai<small>Domain Lead, AI/ML</small></div><div class="what">Leading the AI/ML domain of IIT Bhilai’s open source community. Mentoring builds, reviewing code, recruiting contributors into open source.</div><div class="when">2025 → NOW</div></div>
+      <div class="xp reveal d1" data-detail="xp-openlake"><div class="org">OpenLake, IIT Bhilai<small>Domain Lead, AI/ML</small></div><div class="what">Leading the AI/ML domain of IIT Bhilai’s open source community. Mentoring builds, reviewing code, recruiting contributors into open source.</div><div class="when">2025 → NOW</div></div>
     </div>
   </div>
 </section>
@@ -903,13 +902,6 @@ const DETAILS = {
     </ul>
     <h4>Stack</h4><p>n8n · WhatsApp Business API · Claude · CloseBot</p>
     <p style="margin-top:14px;font-family:var(--mono);font-size:11px;color:var(--muted);">SPECIFICS UNDER NDA</p>`},
-  'xp-ccps': {tag:'2025 → NOW · IIT BHILAI', title:'Placement Coordinator, CCPS', html:`
-    <h4>What I do</h4><ul>
-      <li>Coordinate placements for 200+ students across 30+ companies.</li>
-      <li>Run company outreach, scheduling, and process logistics end to end.</li>
-      <li>Crisis management when interviews, offers and exams collide, which is always.</li>
-    </ul>
-    <h4>What it taught me</h4><p>Stakeholder management at scale: students, companies and faculty all want different things on the same deadline.</p>`},
   'xp-openlake': {tag:'2025 → NOW · IIT BHILAI', title:'Domain Lead AI/ML, OpenLake', html:`
     <h4>What I do</h4><ul>
       <li>Lead the AI/ML domain of IIT Bhilai's open source community.</li>


### PR DESCRIPTION
Closes #5.

Removes the experience card, its detail panel entry, and the CCPS clause in the intro paragraph (reworded, not just deleted, so the sentence still reads). Reveal-delay classes on the remaining experience cards renumbered so the stagger stays sequential.

Verified in a real browser: 6 detail-panel keys resolve (was 7), no JS errors.