### PR TITLE
fix: replace amateur-quality images and rebalance the marquee lanes

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,8 +219,6 @@ section{padding:88px 0;}
 .ct{position:relative;flex:none;height:190px;border-radius:8px;overflow:hidden;box-shadow:0 12px 30px rgba(40,30,12,.22);transition:transform .35s cubic-bezier(.22,1,.36,1),box-shadow .35s;}
 .ct:hover{transform:translateY(-6px) scale(1.03);box-shadow:0 22px 50px rgba(40,30,12,.32);z-index:5;}
 .ct img{height:100%;width:auto;display:block;}
-.ct.crop{width:240px;}
-.ct.crop img{width:100%;height:100%;object-fit:cover;object-position:center;transform:scale(1.45);}
 .ct .cap{position:absolute;left:0;right:0;bottom:0;background:linear-gradient(transparent,rgba(20,15,8,.88));color:var(--bg);font-family:var(--mono);font-size:10px;letter-spacing:.08em;padding:26px 12px 10px;opacity:0;transition:opacity .3s;}
 .ct:hover .cap{opacity:1;}
 .ct.logo{width:190px;background:var(--paper);border:1px solid var(--line);display:flex;align-items:center;justify-content:center;}
@@ -259,7 +257,7 @@ a.oss-stat:hover{transform:translateY(-3px);box-shadow:0 12px 28px rgba(60,45,20
 .lyric.slate{background:#4A5A63;color:#EAF0F2;}
 .lyric.slate .art{background:#33424A;color:#EAF0F2;}
 
-/* ============ MENU ============ */
+/* ============ AVAILABILITY ============ */
 #availability{background:var(--bg2);border-top:1px solid var(--line);border-bottom:1px solid var(--line);}
 .menu-card{max-width:940px;margin:0 auto;background:var(--paper);border:1px solid var(--line2);border-radius:4px;padding:54px 62px;box-shadow:0 24px 60px rgba(60,45,20,.12);position:relative;}
 .menu-block{display:grid;grid-template-columns:1fr 1fr;column-gap:64px;row-gap:4px;align-items:start;}
@@ -521,6 +519,9 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
       <div class="ct"><img src="https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/bb/6d/8f/bb6d8f67-6d04-10b5-dd62-eb5809ac54fc/00602567879152.rgb.jpg/600x600bb.jpg" alt="Scorpion"/><div class="cap">SCORPION · side B supremacy</div></div>
       <div class="ct"><img src="https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/18/9d/b8/189db80b-bfa8-89d1-1514-5fcb7e5cf8f4/00602557611526.rgb.jpg/600x600bb.jpg" alt="More Life"/><div class="cap">MORE LIFE · a playlist, technically</div></div>
       <div class="ct"><img src="https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/7d/4f/94/7d4f9468-56e1-3a2d-7186-c8088170ef58/196871341899.jpg/600x600bb.jpg" alt="Utopia"/><div class="cap">UTOPIA · in my chrome heart era</div></div>
+      <div class="ct"><img src="https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/37/da/7c/37da7cc5-2b6f-9bb8-30ba-8a8c3be3e16a/00602527584973.rgb.jpg/600x600bb.jpg" alt="My Beautiful Dark Twisted Fantasy"/><div class="cap">MBDTF · the ceiling, unmatched</div></div>
+      <div class="ct"><img src="https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/39/25/2d/39252d65-2d50-b991-0962-f7a98a761271/00602517483507.rgb.jpg/600x600bb.jpg" alt="Graduation"/><div class="cap">GRADUATION · bear era supremacy</div></div>
+      <div class="ct"><img src="https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/ee/28/67/ee286794-6c33-a8c2-5c37-c04f1cb5e8a6/21UM1IM54415.rgb.jpg/600x600bb.jpg" alt="2014 Forest Hills Drive"/><div class="cap">2014 FOREST HILLS DRIVE · no features, no filler</div></div>
       <div class="ct logo"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/Claude_AI_symbol.svg/500px-Claude_AI_symbol.svg.png" alt="Claude"/><div class="cap">CLAUDE · listed as emergency contact</div></div>
     </div>
   </div>
@@ -533,23 +534,19 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/en/a/a7/God_of_War_4_cover.jpg" alt="God of War"/><div class="cap">GOD OF WAR · boy.</div></div>
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/en/e/e1/Spider-Man_PS4_cover.jpg" alt="Marvel's Spider-Man"/><div class="cap">SPIDER-MAN · with great power, etc.</div></div>
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/en/4/44/Red_Dead_Redemption_II.jpg" alt="RDR2"/><div class="cap">RDR2 · arthur deserved better</div></div>
-      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/en/0/06/MTH_Poster.jpg" alt="Main Tera Hero"/><div class="cap">MAIN TERA HERO · rewatch count: classified</div></div>
-      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/en/a/a6/FIFA_23_Cover.jpg" alt="FIFA 23"/><div class="cap">FIFA · rage quit certified</div></div>
-      <div class="ct crop" style="width:280px;"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/88/Philadelphia_Eagles_sideline_during_pregame_flag_ceremony.jpg/500px-Philadelphia_Eagles_sideline_during_pregame_flag_ceremony.jpg" alt="Philadelphia Eagles"/><div class="cap">EAGLES · fly eagles fly</div></div>
-      <div class="ct crop" style="width:280px;"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/97/Lockheed_SR-71_Blackbird.jpg/500px-Lockheed_SR-71_Blackbird.jpg" alt="SR-71 Blackbird"/><div class="cap">SR-71 · fastest thing ever built, still humble</div></div>
+      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/en/a/a6/FIFA_23_Cover.jpg" alt="FIFA 23"/><div class="cap">FIFA 23 · rage quit certified</div></div>
+      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/en/6/6c/FIFA_22_Cover.jpg" alt="FIFA 22"/><div class="cap">FIFA 22 · kickoff, straight to career mode</div></div>
+      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Valorant_Clove_Agent25_KeyArt-1024x576-1.jpg/960px-Valorant_Clove_Agent25_KeyArt-1024x576-1.jpg" alt="Valorant"/><div class="cap">VALORANT · queueing with the boys</div></div>
     </div>
   </div>
 
   <!-- lane 3: the athletes & the machines -->
   <div class="car-row reveal">
     <div class="car-track" id="car3" style="animation-duration:60s;">
-      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8e/Cristiano-ronaldo-juventus-2019.jpg/960px-Cristiano-ronaldo-juventus-2019.jpg" alt="Cristiano Ronaldo"/><div class="cap">CR7 · the standard</div></div>
+      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/f/fc/Cristiano_Ronaldo_Al-Nassr_2023.jpg" alt="Cristiano Ronaldo"/><div class="cap">CR7 · the standard</div></div>
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Sergio_Ramos_Confederations_Cup_2013_%28cropped%29.jpg/960px-Sergio_Ramos_Confederations_Cup_2013_%28cropped%29.jpg" alt="Sergio Ramos"/><div class="cap">RAMOS · minute 92:48</div></div>
       <div class="ct" style="background:var(--paper);"><img src="https://upload.wikimedia.org/wikipedia/commons/d/db/Luka_Modric_2018.png" alt="Luka Modric"/><div class="cap">MODRIĆ · midfield royalty</div></div>
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/LeBron_James_Layup_%28Cleveland_vs_Brooklyn_2018%29.jpg/960px-LeBron_James_Layup_%28Cleveland_vs_Brooklyn_2018%29.jpg" alt="LeBron James"/><div class="cap">BRON · witness.</div></div>
-      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f2/Jalen_Brunson_2023_%28cropped%29.jpg/960px-Jalen_Brunson_2023_%28cropped%29.jpg" alt="Jalen Brunson"/><div class="cap">BRUNSON · clutch gene</div></div>
-      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Dwyane_Wade_e1_%28cropped%29.jpg/960px-Dwyane_Wade_e1_%28cropped%29.jpg" alt="Dwyane Wade"/><div class="cap">D-WADE · this is my house</div></div>
-      <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/6/65/Lipofsky_Shaquille_O%27Neal.jpg" alt="Shaquille O'Neal"/><div class="cap">SHAQ · most dominant ever</div></div>
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Justin_Jefferson_Commanders_vs_Vikings_NOV2022.jpg/960px-Justin_Jefferson_Commanders_vs_Vikings_NOV2022.jpg" alt="Justin Jefferson"/><div class="cap">JETTAS · griddy season</div></div>
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Saquon_Barkley_Giants_2018.jpg/960px-Saquon_Barkley_Giants_2018.jpg" alt="Saquon Barkley"/><div class="cap">SAQUON · gravity is optional</div></div>
       <div class="ct"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Bugatti_Chiron%2C_GIMS_2018%2C_Le_Grand-Saconnex_%281X7A1765%29.jpg/960px-Bugatti_Chiron%2C_GIMS_2018%2C_Le_Grand-Saconnex_%281X7A1765%29.jpg" alt="Bugatti Chiron"/><div class="cap">CHIRON · 1500 horses, zero chill</div></div>
@@ -559,7 +556,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
   </div>
 </section>
 
-<!-- ════════ MENU ════════ -->
+<!-- ════════ AVAILABILITY ════════ -->
 <section id="availability">
   <div class="deco blob slow" style="width:160px;height:160px;top:10%;right:4%;"></div>
   <div class="wrap">


### PR DESCRIPTION
Progress on #6.

Reviewed all 30 marquee images individually (not from filenames/URLs) against a "nothing a pro wouldn't post" bar. Three failed:

- **Philadelphia Eagles** - a random photographer kneeling on the field, no recognizable player
- **Cristiano Ronaldo** - buried at the frame edge in a 5-player crowd shot, with a visible "soccerru" stock-photo watermark
- **Main Tera Hero** - a garish comic-panel Bollywood poster next to moody AAA game box art

Also rebalanced content: dropped Brunson/Wade/Shaq (fine quality, but redundant NBA closeups), added two Kanye covers, a J. Cole cover, Valorant key art, and a second FIFA cover.

Landed thematically rather than 1:1:
- **lane 1** (music) gains MBDTF, Graduation, 2014 Forest Hills Drive
- **lane 2** (games) drops Eagles/SR-71/Main Tera Hero - none of which were actually games - gains FIFA 22 and Valorant, so "the library" is now consistently game covers for the first time
- **lane 3** (athletes) loses the three removed players, kept pure

Ronaldo replaced with a clean single-subject portrait (Al-Nassr, 2023), matching the Ramos/Modric register already in the lane.

Every replacement sourced from iTunes or Wikimedia Commons and verified by downloading and viewing each one before use.

Verified in a browser: 0 broken images across all three lanes, counts exact, no JS errors.

Remaining on #6: `will-change`, `prefers-reduced-motion`, `loading=lazy`, explicit dimensions. Separate PR.