### PR TITLE
fix: copy email to clipboard as a fallback when mailto has no handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -786,6 +786,18 @@ document.querySelectorAll('.car-row').forEach(r => {
   let h; r.addEventListener('mouseenter', () => h = setTimeout(() => unlock('taste'), 2000));
   r.addEventListener('mouseleave', () => clearTimeout(h));
 });
+/* email row: mailto only fires if the visitor has a mail client set as
+   default, which plenty of people don't. Copy to clipboard alongside it
+   so the address is usable either way. */
+const emailRow = document.querySelector('.inbox-row[href^="mailto:"]');
+if (emailRow && navigator.clipboard) {
+  emailRow.addEventListener('click', () => {
+    const email = emailRow.href.replace('mailto:', '');
+    navigator.clipboard.writeText(email)
+      .then(() => toast('EMAIL COPIED', email + ' is on your clipboard, in case nothing opened.'))
+      .catch(() => {});
+  });
+}
 
 /* ---------- latest lore (from posts.js) ---------- */
 (function(){


### PR DESCRIPTION
mailto: only fires if the visitor's OS has a default mail client set. Clicking the email row now also copies the address and confirms it via the existing toast, so it still works for people who don't.