### PR TITLE
fix: On Repeat as Spotify-style rows with real album art

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   --paper:#FDFAF2;
   --ink:#1C1812; --ink2:#594E3B; --muted:#8A7A5C;
   --line:#E2D7BE; --line2:#D4C7A6;
-  --terra:#B5532F; --olive:#3F5A36; --brass:#C8922F;
+  --terra:#B5532F; --olive:#3F5A36; --brass:#C8922F; --slate:#4A5A63;
   --serif:'Fraunces',Georgia,serif;
   --sans:'Hanken Grotesk',system-ui,sans-serif;
   --mono:'JetBrains Mono',monospace;
@@ -255,26 +255,30 @@ a.oss-stat:hover{transform:translateY(-3px);box-shadow:0 12px 28px rgba(60,45,20
 #repeat .sec-title{color:var(--bg);}
 #repeat .label{color:rgba(247,241,229,.5);}
 #repeat .sec-intro{color:rgba(247,241,229,.6);}
-.lyric-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:18px;}
-.lyric{border-radius:18px;padding:26px;display:flex;flex-direction:column;gap:26px;min-height:330px;transition:transform .3s cubic-bezier(.22,1,.36,1);}
-.lyric:hover{transform:translateY(-6px) rotate(-.5deg);}
-.lyric .head{display:flex;align-items:center;gap:11px;}
-.lyric .art{width:42px;height:42px;border-radius:4px;display:flex;align-items:center;justify-content:center;font-family:var(--serif);font-weight:700;font-size:16px;flex:none;}
-.lyric .track{font-weight:700;font-size:13px;letter-spacing:.01em;line-height:1.3;}
-.lyric .artist{font-size:12px;opacity:.6;margin-top:1px;}
-.lyric .bars{font-family:var(--sans);font-weight:800;font-size:27px;line-height:1.3;letter-spacing:-.02em;flex:1;}
-.lyric .bars .dim{opacity:.4;display:block;}
-.lyric .brandrow{display:flex;align-items:center;gap:9px;font-weight:700;font-size:13.5px;letter-spacing:.01em;}
-.lyric .brandrow .note{width:21px;height:21px;border-radius:50%;border:2px solid currentColor;display:flex;align-items:center;justify-content:center;font-size:10px;line-height:1;}
-.lyric.terra{background:#B5532F;color:#FBEFE6;}
-.lyric.terra .art{background:#8C3A1D;color:#FBEFE6;}
-.lyric.olive{background:#3F5A36;color:#EDF3E8;}
-.lyric.olive .art{background:#2C4126;color:#EDF3E8;}
-.lyric.brass{background:#2A2118;color:#F0DDA8;}
-.lyric.brass .art{background:#C8922F;color:#2A2118;}
-/* Not --ink: the section itself is --ink, so that colour is invisible here. */
-.lyric.slate{background:#4A5A63;color:#EAF0F2;}
-.lyric.slate .art{background:#33424A;color:#EAF0F2;}
+/* Spotify-row layout: real cover art on the left of the header instead of
+   a flat number badge, one neutral dark card surface instead of painting
+   each card a full saturated colour - the accent lives in the left
+   border + brandrow only, same idiom as .take's border-left elsewhere. */
+.lyric-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:18px;}
+@media(max-width:900px){.lyric-grid{grid-template-columns:repeat(2,1fr);}}
+@media(max-width:560px){.lyric-grid{grid-template-columns:1fr;}}
+.lyric{background:#1E1B17;border:1px solid rgba(247,241,229,.08);border-left:3px solid var(--line2);border-radius:14px;padding:22px;display:flex;flex-direction:column;gap:20px;min-height:280px;color:#F7F1E5;transition:transform .3s cubic-bezier(.22,1,.36,1),border-color .3s;}
+.lyric:hover{transform:translateY(-6px);}
+.lyric .head{display:flex;align-items:center;gap:14px;}
+.lyric .art{width:56px;height:56px;border-radius:6px;object-fit:cover;flex:none;box-shadow:0 8px 18px rgba(0,0,0,.4);}
+.lyric .track{font-weight:700;font-size:14px;letter-spacing:.005em;line-height:1.3;}
+.lyric .artist{font-size:12px;color:rgba(247,241,229,.55);margin-top:2px;}
+.lyric .bars{font-family:var(--sans);font-weight:700;font-size:18px;line-height:1.42;letter-spacing:-.01em;flex:1;}
+.lyric .brandrow{display:flex;align-items:center;gap:9px;font-weight:700;font-size:12px;letter-spacing:.04em;text-transform:uppercase;}
+.lyric .brandrow .note{width:20px;height:20px;border-radius:50%;border:2px solid currentColor;display:flex;align-items:center;justify-content:center;font-size:10px;line-height:1;}
+.lyric.terra{border-left-color:var(--terra);}
+.lyric.terra .brandrow{color:var(--terra);}
+.lyric.olive{border-left-color:var(--olive);}
+.lyric.olive .brandrow{color:var(--olive);}
+.lyric.brass{border-left-color:var(--brass);}
+.lyric.brass .brandrow{color:var(--brass);}
+.lyric.slate{border-left-color:var(--slate);}
+.lyric.slate .brandrow{color:var(--slate);}
 
 /* ============ HOT TAKES ============ */
 .takes-grid{display:grid;grid-template-columns:1fr 1fr;gap:18px;}
@@ -626,22 +630,22 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
     <p class="sec-intro reveal">Four tracks I have not gotten tired of. No curation, just what is stuck.</p>
     <div class="lyric-grid">
       <div class="lyric terra reveal">
-        <div class="head"><div class="art">01</div><div><div class="track">Forever</div><div class="artist">Drake, Kanye West, Lil Wayne &amp; Eminem</div></div></div>
+        <div class="head"><img class="art" src="https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/b2/eb/92/b2eb92ce-84f7-9ccd-709f-063c30de71c3/00602527307749.rgb.jpg/600x600bb.jpg" alt="" width="56" height="56" loading="lazy"><div><div class="track">Forever</div><div class="artist">Drake, Kanye West, Lil Wayne &amp; Eminem</div></div></div>
         <div class="bars">“Last name ever, first name greatest.”</div>
         <div class="brandrow"><span class="note">♪</span>ON REPEAT</div>
       </div>
       <div class="lyric olive reveal d1">
-        <div class="head"><div class="art">02</div><div><div class="track">Till I Collapse</div><div class="artist">Eminem feat. Nate Dogg</div></div></div>
+        <div class="head"><img class="art" src="https://is1-ssl.mzstatic.com/image/thumb/Music118/v4/dd/5c/e6/dd5ce621-f7d2-f767-7a08-e7a7eaa7870b/00602537526994.rgb.jpg/600x600bb.jpg" alt="" width="56" height="56" loading="lazy"><div><div class="track">Till I Collapse</div><div class="artist">Eminem feat. Nate Dogg</div></div></div>
         <div class="bars">“Sometimes you just feel tired, feel weak, and when you feel weak you feel like you wanna just give up.”</div>
         <div class="brandrow"><span class="note">♪</span>ON REPEAT</div>
       </div>
       <div class="lyric brass reveal d2">
-        <div class="head"><div class="art">03</div><div><div class="track">Can’t Tell Me Nothing</div><div class="artist">Kanye West</div></div></div>
+        <div class="head"><img class="art" src="https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/39/25/2d/39252d65-2d50-b991-0962-f7a98a761271/00602517483507.rgb.jpg/600x600bb.jpg" alt="" width="56" height="56" loading="lazy"><div><div class="track">Can’t Tell Me Nothing</div><div class="artist">Kanye West</div></div></div>
         <div class="bars">“When I woke up I spent that on a necklace.”</div>
         <div class="brandrow"><span class="note">♪</span>ON REPEAT</div>
       </div>
       <div class="lyric slate reveal d2">
-        <div class="head"><div class="art">04</div><div><div class="track">False Prophets</div><div class="artist">J. Cole</div></div></div>
+        <div class="head"><img class="art" src="https://is1-ssl.mzstatic.com/image/thumb/Music128/v4/d9/58/61/d958617d-8217-ec6e-4c13-dce08ad03045/00850498007728.rgb.jpg/600x600bb.jpg" alt="" width="56" height="56" loading="lazy"><div><div class="track">False Prophets</div><div class="artist">J. Cole</div></div></div>
         <div class="bars">“He’s so bitter he can’t see his own blessings.”</div>
         <div class="brandrow"><span class="note">♪</span>ON REPEAT</div>
       </div>


### PR DESCRIPTION
closes #23

Real album art (iTunes cover art API, same source as the other marquee lanes) on the left of each card instead of a flat number badge. One neutral dark card surface instead of painting each card a full saturated colour - the accent moved to the left border + brandrow, same idiom as .take's border-left elsewhere. 4 columns on desktop, collapsing to 2 then 1.