### PR TITLE
feat: elevate the sliding marquee, inspired by vatsalyd/Portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,14 @@ section{padding:88px 0;}
 
 /* ============ COLLECTION (carousel) ============ */
 #collection{overflow:hidden;}
-.car-row{overflow:hidden;margin-bottom:18px;}
+/* Edge-mask fade + always-partly-visible caption + hover image zoom,
+   borrowed from vatsalyd/Portfolio's Characters reel (adapted colours,
+   not copied) - keeps every card's real aspect ratio rather than
+   cropping to a uniform poster, since those were fetched deliberately. */
+.car-row{overflow:hidden;margin-bottom:18px;
+  mask-image:linear-gradient(to right,transparent 0,#000 4%,#000 96%,transparent 100%);
+  -webkit-mask-image:linear-gradient(to right,transparent 0,#000 4%,#000 96%,transparent 100%);
+}
 .car-track{display:flex;gap:16px;width:max-content;animation:carL 45s linear infinite;}
 .car-track.rev{animation-name:carR;animation-duration:52s;}
 .car-row:hover .car-track{animation-play-state:paused;}
@@ -235,10 +242,11 @@ section{padding:88px 0;}
 @media (prefers-reduced-motion: reduce){
   .car-track{animation:none!important;}
 }
-.ct{position:relative;flex:none;height:190px;border-radius:8px;overflow:hidden;box-shadow:0 12px 30px rgba(40,30,12,.22);transition:transform .35s cubic-bezier(.22,1,.36,1),box-shadow .35s;}
-.ct:hover{transform:translateY(-6px) scale(1.03);box-shadow:0 22px 50px rgba(40,30,12,.32);z-index:5;}
-.ct img{height:100%;width:auto;display:block;}
-.ct .cap{position:absolute;left:0;right:0;bottom:0;background:linear-gradient(transparent,rgba(20,15,8,.88));color:var(--bg);font-family:var(--mono);font-size:10px;letter-spacing:.08em;padding:26px 12px 10px;opacity:0;transition:opacity .3s;}
+.ct{position:relative;flex:none;height:190px;border-radius:10px;overflow:hidden;box-shadow:0 12px 30px rgba(40,30,12,.22),0 0 0 0 var(--brass);transition:transform .4s cubic-bezier(.22,1,.36,1),box-shadow .4s;}
+.ct:hover{transform:translateY(-8px) scale(1.035);box-shadow:0 24px 54px rgba(40,30,12,.34),0 0 0 2px var(--brass);z-index:5;}
+.ct img{height:100%;width:auto;display:block;transition:transform .5s ease;}
+.ct:hover img{transform:scale(1.07);}
+.ct .cap{position:absolute;left:0;right:0;bottom:0;background:linear-gradient(transparent,rgba(20,15,8,.92) 65%);color:var(--bg);font-family:var(--mono);font-size:10px;letter-spacing:.08em;padding:34px 12px 10px;opacity:.72;transition:opacity .3s;}
 .ct:hover .cap{opacity:1;}
 .ct.logo{width:190px;background:var(--paper);border:1px solid var(--line);display:flex;align-items:center;justify-content:center;}
 .ct.logo img{height:auto;width:54%;}


### PR DESCRIPTION
closes #24

Reference: github.com/vatsalyd/Portfolio's Characters reel - not copied, adapted into the existing terra/olive/brass palette.

- edge-mask fade on each car-row so cards fade in/out at the edges instead of a hard cut
- caption readable at rest (opacity .72) instead of fully hidden until hover
- hover: deeper lift, a brass ring, image zooms slightly for depth

Deliberately kept each card's real per-image aspect ratio rather than cropping to a uniform poster grid - those were fetched individually in an earlier pass and a hard crop would need per-image framing to not cut off faces/logos across ~28 very different images. Happy to do that pass too if you still want the stricter poster-grid look after seeing this.