### PR TITLE
fix: make marquee poster cards bigger

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,15 +247,15 @@ section{padding:88px 0;}
 @media (prefers-reduced-motion: reduce){
   .car-track{animation:none!important;}
 }
-.ct{position:relative;flex:none;width:180px;background:var(--paper);border:1px solid var(--line2);border-radius:14px;padding:10px 10px 14px;box-shadow:0 12px 30px rgba(40,30,12,.18),0 0 0 0 var(--brass);transition:transform .4s cubic-bezier(.22,1,.36,1),box-shadow .4s;}
-.ct:hover{transform:translateY(-8px) scale(1.025);box-shadow:0 26px 56px rgba(40,30,12,.3),0 0 0 2px var(--brass);z-index:5;}
-.ct-frame{position:relative;width:100%;aspect-ratio:2/3;border-radius:8px;overflow:hidden;background:#18161a;}
+.ct{position:relative;flex:none;width:260px;background:var(--paper);border:1px solid var(--line2);border-radius:16px;padding:14px 14px 18px;box-shadow:0 14px 34px rgba(40,30,12,.18),0 0 0 0 var(--brass);transition:transform .4s cubic-bezier(.22,1,.36,1),box-shadow .4s;}
+.ct:hover{transform:translateY(-10px) scale(1.02);box-shadow:0 30px 64px rgba(40,30,12,.3),0 0 0 2px var(--brass);z-index:5;}
+.ct-frame{position:relative;width:100%;aspect-ratio:2/3;border-radius:10px;overflow:hidden;background:#18161a;}
 .ct-frame img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .5s ease;}
 .ct:hover .ct-frame img{transform:scale(1.06);}
-.ct-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(15,12,8,.9) 0%,rgba(15,12,8,.35) 55%,transparent 100%);display:flex;align-items:flex-end;padding:14px;opacity:0;transition:opacity .3s;}
+.ct-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(15,12,8,.9) 0%,rgba(15,12,8,.35) 55%,transparent 100%);display:flex;align-items:flex-end;padding:18px;opacity:0;transition:opacity .3s;}
 .ct:hover .ct-overlay{opacity:1;}
-.ct-overlay span{font-family:var(--mono);font-size:10.5px;font-style:italic;color:var(--bg);line-height:1.4;}
-.ct-cap{margin-top:11px;padding:0 2px;font-family:var(--serif);font-weight:600;font-size:13.5px;color:var(--ink);letter-spacing:.005em;line-height:1.25;}
+.ct-overlay span{font-family:var(--mono);font-size:12px;font-style:italic;color:var(--bg);line-height:1.45;}
+.ct-cap{margin-top:14px;padding:0 2px;font-family:var(--serif);font-weight:600;font-size:16px;color:var(--ink);letter-spacing:.005em;line-height:1.25;}
 .ct.logo .ct-frame{background:var(--paper);display:flex;align-items:center;justify-content:center;}
 .ct.logo .ct-frame img{width:54%;height:54%;object-fit:contain;}
 
@@ -367,7 +367,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
   .xp .when{order:-1;}
   .win-pane{padding:26px 22px 24px;}
   .nav-links{display:none;}
-  .ct{width:130px;}
+  .ct{width:190px;}
   .about-grid{grid-template-columns:1fr;}
   .deco{display:none;}
 }


### PR DESCRIPTION
Cards were 180px wide, too small for the poster art to actually read - text on the smaller posters got lost. Bumped to 260px (190px on mobile), with proportionally larger overlay/caption text.