### PR TITLE
feat: replace lane 3 cars with real film posters

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
     <rect x="98" y="5" width="16" height="16" fill="none" stroke="#A6588A" stroke-width="2.2"/>
   </svg>
   <div class="wrap">
-    <div class="sec-head reveal"><h2 class="sec-title">The Collection</h2><span class="label">ALBUMS · GAMES · CHARACTERS · MACHINES</span></div>
+    <div class="sec-head reveal"><h2 class="sec-title">The Collection</h2><span class="label">ALBUMS · GAMES · FILMS</span></div>
     <p class="sec-intro reveal">The taste section. Three lanes, alternating directions, hover to pause and read the commentary.</p>
   </div>
 
@@ -605,15 +605,15 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
     </div>
   </div>
 
-  <!-- lane 3: the characters & the machines -->
+  <!-- lane 3: the films -->
   <div class="car-row reveal">
     <div class="car-track" id="car3" style="animation-duration:60s;">
       <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/1/1c/Godfather_ver1.jpg" alt="The Godfather" loading="lazy"/><div class="ct-overlay"><span>an offer nobody refused</span></div></div><div class="ct-cap">THE GODFATHER</div></div>
-      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/1/1c/The_Dark_Knight_%282008_film%29.jpg" alt="The Dark Knight" loading="lazy"/><div class="ct-overlay"><span>the standard nothing has matched since</span></div></div><div class="ct-cap">THE DARK KNIGHT</div></div>
-      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/9/9f/Blade_Runner_%281982_poster%29.png" alt="Blade Runner" loading="lazy"/><div class="ct-overlay"><span>more human than human</span></div></div><div class="ct-cap">BLADE RUNNER</div></div>
-      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Bugatti_Chiron%2C_GIMS_2018%2C_Le_Grand-Saconnex_%281X7A1765%29.jpg/960px-Bugatti_Chiron%2C_GIMS_2018%2C_Le_Grand-Saconnex_%281X7A1765%29.jpg" alt="Bugatti Chiron" loading="lazy"/><div class="ct-overlay"><span>1500 horses, zero chill</span></div></div><div class="ct-cap">CHIRON</div></div>
-      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0f/Lamborghini_Aventador%2C_Motortreff_Bella_Italia_2024%2C_Munich_%28P1190389-RR%29.jpg/960px-Lamborghini_Aventador%2C_Motortreff_Bella_Italia_2024%2C_Munich_%28P1190389-RR%29.jpg" alt="Lamborghini Aventador" loading="lazy"/><div class="ct-overlay"><span>the poster car</span></div></div><div class="ct-cap">AVENTADOR</div></div>
-      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Koenigsegg_Agera%2C_GIMS_2018_07.jpg/960px-Koenigsegg_Agera%2C_GIMS_2018_07.jpg" alt="Koenigsegg Agera" loading="lazy"/><div class="ct-overlay"><span>swedish physics violation</span></div></div><div class="ct-cap">AGERA</div></div>
+      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/9/90/The_Odyssey_%282026_film%29_poster.jpg" alt="The Odyssey" loading="lazy"/><div class="ct-overlay"><span>a film by christopher nolan</span></div></div><div class="ct-cap">THE ODYSSEY</div></div>
+      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/4/4a/Oppenheimer_%28film%29.jpg" alt="Oppenheimer" loading="lazy"/><div class="ct-overlay"><span>now I am become death</span></div></div><div class="ct-cap">OPPENHEIMER</div></div>
+      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/6/68/Ocean%27s_Eleven_2001_Poster.jpg" alt="Ocean's Eleven" loading="lazy"/><div class="ct-overlay"><span>are you in or are you out</span></div></div><div class="ct-cap">OCEAN'S ELEVEN</div></div>
+      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/1/13/Top_Gun_Maverick_Poster.jpg" alt="Top Gun: Maverick" loading="lazy"/><div class="ct-overlay"><span>talk to me, Goose</span></div></div><div class="ct-cap">TOP GUN: MAVERICK</div></div>
+      <div class="ct"><div class="ct-frame"><img src="https://upload.wikimedia.org/wikipedia/en/b/bc/Interstellar_film_poster.jpg" alt="Interstellar" loading="lazy"/><div class="ct-overlay"><span>go further</span></div></div><div class="ct-cap">INTERSTELLAR</div></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Dropped the three supercar photos, replaced with six real official theatrical posters: The Godfather, The Odyssey, Oppenheimer, Ocean's Eleven, Top Gun: Maverick, Interstellar. Label updated from ALBUMS · GAMES · CHARACTERS · MACHINES to ALBUMS · GAMES · FILMS since the lane is now entirely posters.

Sourced from English Wikipedia's non-free media (same as every other poster/cover in the marquee) - real theatrical one-sheets, not the stylized fan/limited-edition art prints that circulate for some of these (Ocean's Eleven has a well-known illustrated alternative poster with no clear reuse rights, used the actual 2001 studio release poster instead).