### PR TITLE
Collection controller: remove Rayquaza, fix cropping, add drag

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,9 @@ section > .wrap{position:relative;z-index:1;}
 .deco-stamp rect{fill:none;stroke:var(--terra);stroke-width:2.4;}
 .deco-stamp .st-t{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:1.6px;fill:var(--terra);}
 .deco-stamp .st-n{font-family:var(--mono);font-size:19px;font-weight:700;letter-spacing:.6px;fill:var(--terra);}
-.deco-ray{position:absolute;pointer-events:none;z-index:0;opacity:.14;}
 .deco-ps{position:absolute;pointer-events:none;z-index:0;opacity:.5;}
-.collection-controller{position:absolute;top:-58px;right:0;width:130px;height:130px;z-index:1;pointer-events:none;}
+.collection-controller{position:absolute;top:-40px;right:10px;width:220px;height:220px;z-index:1;cursor:grab;touch-action:none;}
+.collection-controller:active{cursor:grabbing;}
 .collection-controller canvas{width:100%;height:100%;display:block;}
 @media (max-width:900px){.collection-controller{display:none;}}
 .deco-tag{position:absolute;pointer-events:none;z-index:0;font-family:'Permanent Marker',cursive;font-size:2.4rem;line-height:1;color:var(--terra);opacity:.22;width:max-content;}
@@ -265,7 +265,7 @@ section{padding:88px 0;}
 #pr-status{font-family:var(--mono);font-size:11px;color:var(--muted);margin-top:14px;}
 
 /* ============ COLLECTION (carousel) ============ */
-#collection{overflow:hidden;}
+#collection{overflow:hidden;padding-top:160px;}
 /* Mat-frame poster cards: a paper card with padding around the image
    (like a framed print), a persistent title below, and commentary that
    only appears on hover, over the image itself - not baked in at rest.
@@ -633,9 +633,6 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
 
 <!-- ════════ COLLECTION ════════ -->
 <section id="collection">
-  <img class="deco-ray" src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/384.png"
-       alt="" width="475" height="475" loading="lazy"
-       style="width:130px;height:130px;top:8px;right:24px;transform:rotate(8deg);">
   <svg class="deco-ps" style="width:120px;height:30px;top:24px;left:30px;transform:rotate(-3deg);" viewBox="0 0 120 30">
     <polygon points="15,3 26,24 4,24" fill="none" stroke="#4A9B7F" stroke-width="2.2" stroke-linejoin="round"/>
     <circle cx="49" cy="15" r="11" fill="none" stroke="#B5532F" stroke-width="2.2"/>
@@ -1291,11 +1288,9 @@ document.querySelectorAll('.ct').forEach(c => {
    heading. measuring .sec-intro's actual bottom clears both at once. */
 (function () {
   var intro = document.querySelector('#collection .sec-intro');
-  var ray = document.querySelector('#collection .deco-ray');
   var ps = document.querySelector('#collection .deco-ps');
-  if (intro && ray && ps) {
+  if (intro && ps) {
     var y = intro.offsetTop + intro.offsetHeight + 14;
-    ray.style.top = y + 'px';
     ps.style.top = (y + 4) + 'px';
   }
 })();
@@ -1312,7 +1307,7 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
   if (!wrap || !canvasEl || typeof THREE === 'undefined') return;
 
   var section = document.getElementById('collection');
-  var baseRotY = -1.05; // turned so the grips trail off to the left
+  var baseRotY = -1.05 + Math.PI; // flipped 180° from the first pass - buttons face left now
   var scene, camera, renderer, pad;
 
   try {
@@ -1349,7 +1344,10 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
       pad.rotation.y = baseRotY;
 
       var maxDim = Math.max(size.x, size.y, size.z);
-      var dist = maxDim * 2.7;
+      // generous margin: the base yaw plus the scroll swing plus manual
+      // drag can all present a wider diagonal silhouette than the
+      // axis-aligned bounding box, so a tight fit crops it at the extremes
+      var dist = maxDim * 4.2;
       camera.position.set(0, maxDim * 0.35, dist);
       camera.lookAt(0, 0, 0);
       camera.near = dist / 100;
@@ -1367,23 +1365,41 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
   }
 
   function resize(){
-    var w = wrap.clientWidth || 130, h = wrap.clientHeight || 130;
+    var w = wrap.clientWidth || 220, h = wrap.clientHeight || 220;
     renderer.setSize(w, h, false);
     camera.aspect = w / h;
     camera.updateProjectionMatrix();
   }
   addEventListener('resize', resize);
 
+  /* drag to spin it yourself; scroll position sets a slow base swing when
+     you're not actively holding it, so it's never fully inert */
+  var dragging = false, lastX = 0, dragOffset = 0;
+  wrap.addEventListener('pointerdown', function (e) {
+    dragging = true; lastX = e.clientX; wrap.setPointerCapture(e.pointerId);
+  });
+  wrap.addEventListener('pointerup', function () { dragging = false; });
+  wrap.addEventListener('pointercancel', function () { dragging = false; });
+  wrap.addEventListener('pointermove', function (e) {
+    if (!dragging) return;
+    dragOffset += (e.clientX - lastX) * 0.012;
+    lastX = e.clientX;
+  });
+
   /* slow, scroll-tied turn: as the section drifts through the viewport,
      the controller eases further round from its base angle and back -
-     no free-running animation, it only moves because you're scrolling */
+     dragging adds on top of that instead of fighting it */
   function tick(){
-    if (!prefersReducedMotion && section && pad) {
-      var rect = section.getBoundingClientRect();
-      var vh = innerHeight || document.documentElement.clientHeight;
-      var progress = (vh / 2 - (rect.top + rect.height / 2)) / (vh / 2 + rect.height / 2);
-      progress = Math.max(-1, Math.min(1, progress));
-      pad.rotation.y = baseRotY + progress * 0.3;
+    if (pad) {
+      var scrollSwing = 0;
+      if (!prefersReducedMotion && section) {
+        var rect = section.getBoundingClientRect();
+        var vh = innerHeight || document.documentElement.clientHeight;
+        var progress = (vh / 2 - (rect.top + rect.height / 2)) / (vh / 2 + rect.height / 2);
+        progress = Math.max(-1, Math.min(1, progress));
+        scrollSwing = progress * 0.3;
+      }
+      pad.rotation.y = baseRotY + scrollSwing + dragOffset;
     }
     renderer.render(scene, camera);
     requestAnimationFrame(tick);


### PR DESCRIPTION
follow-up to #57.

- removed the Rayquaza deco image (never rendered right), controller now uses that space
- added padding-top to #collection for real distance from Open Source above
- widened camera distance, was cropping/overlapping the label at scroll extremes
- flipped 180 degrees, buttons face left now
- added drag-to-rotate (was pointer-events:none, totally inert before)