### PR TITLE
Fix controller orientation, add Z-axis drag, restore the glyph

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@ section > .wrap{position:relative;z-index:1;}
 .deco-stamp rect{fill:none;stroke:var(--terra);stroke-width:2.4;}
 .deco-stamp .st-t{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:1.6px;fill:var(--terra);}
 .deco-stamp .st-n{font-family:var(--mono);font-size:19px;font-weight:700;letter-spacing:.6px;fill:var(--terra);}
+.deco-ps{display:block;width:120px;height:30px;opacity:.5;pointer-events:none;margin:4px 0 0 2px;}
 .collection-head-row{display:grid;grid-template-columns:auto 1fr;align-items:center;gap:20px;margin-bottom:36px;}
 .collection-controller{position:relative;width:400px;height:400px;flex:none;cursor:grab;touch-action:none;}
 .collection-controller:active{cursor:grabbing;}
@@ -650,6 +651,13 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
         <p class="sec-intro reveal">The taste section. Three lanes, alternating directions, hover to pause and read the commentary.</p>
       </div>
     </div>
+    <svg class="deco-ps" style="transform:rotate(-3deg);" viewBox="0 0 120 30">
+      <polygon points="15,3 26,24 4,24" fill="none" stroke="#4A9B7F" stroke-width="2.2" stroke-linejoin="round"/>
+      <circle cx="49" cy="15" r="11" fill="none" stroke="#B5532F" stroke-width="2.2"/>
+      <line x1="70" y1="5" x2="87" y2="24" stroke="#5B7FA6" stroke-width="2.4" stroke-linecap="round"/>
+      <line x1="87" y1="5" x2="70" y2="24" stroke="#5B7FA6" stroke-width="2.4" stroke-linecap="round"/>
+      <rect x="98" y="5" width="16" height="16" fill="none" stroke="#A6588A" stroke-width="2.2"/>
+    </svg>
   </div>
 
   <!-- lane 1: the rotation -->
@@ -1300,7 +1308,9 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
   if (!wrap || !canvasEl || typeof THREE === 'undefined') return;
 
   var section = document.getElementById('collection');
-  var baseRotY = -1.05 + Math.PI; // flipped 180° from the first pass - buttons face left now
+  // negated from the earlier value: flipping the model upright (below) mirrors
+  // which yaw angle reads as "buttons on the left", so the sign has to flip too
+  var baseRotY = 1.05 - Math.PI;
   var scene, camera, renderer, pad;
 
   try {
@@ -1333,6 +1343,7 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
       box.getSize(size);
       box.getCenter(center);
       model.position.sub(center);
+      model.rotation.x = Math.PI; // the raw model sits upside down at rest
       pad.add(model);
       pad.rotation.y = baseRotY;
 
@@ -1369,18 +1380,21 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
   }
   addEventListener('resize', resize);
 
-  /* drag to spin it yourself; scroll position sets a slow base swing when
-     you're not actively holding it, so it's never fully inert */
-  var dragging = false, lastX = 0, dragOffset = 0;
+  /* drag to spin it yourself - horizontal drag turns it (Y), vertical drag
+     rolls it (Z), like spinning a coin on a table. scroll position sets a
+     slow base swing on Y when you're not actively holding it */
+  var dragging = false, lastX = 0, lastY = 0, dragOffsetY = 0, dragOffsetZ = 0;
   wrap.addEventListener('pointerdown', function (e) {
-    dragging = true; lastX = e.clientX; wrap.setPointerCapture(e.pointerId);
+    dragging = true; lastX = e.clientX; lastY = e.clientY; wrap.setPointerCapture(e.pointerId);
   });
   wrap.addEventListener('pointerup', function () { dragging = false; });
   wrap.addEventListener('pointercancel', function () { dragging = false; });
   wrap.addEventListener('pointermove', function (e) {
     if (!dragging) return;
-    dragOffset += (e.clientX - lastX) * 0.012;
+    dragOffsetY += (e.clientX - lastX) * 0.012;
+    dragOffsetZ += (e.clientY - lastY) * 0.012;
     lastX = e.clientX;
+    lastY = e.clientY;
   });
 
   /* slow, scroll-tied turn: as the section drifts through the viewport,
@@ -1396,7 +1410,8 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
         progress = Math.max(-1, Math.min(1, progress));
         scrollSwing = progress * 0.3;
       }
-      pad.rotation.y = baseRotY + scrollSwing + dragOffset;
+      pad.rotation.y = baseRotY + scrollSwing + dragOffsetY;
+      pad.rotation.z = dragOffsetZ;
     }
     renderer.render(scene, camera);
     requestAnimationFrame(tick);


### PR DESCRIPTION
follow-up to #59.

- model was upside down (grips top, body bottom) - flipped 180° on X. that flips which yaw reads as buttons-left too, so baseRotY's sign flipped along with it
- drag now does two axes: horizontal = yaw (Y), vertical = roll (Z, new)
- PS-glyph is back, placed in normal flow below the header row this time (not absolute + JS-measured like before) so it can't overlap the controller no matter what