### PR TITLE
Real trackball rotation for the controller, stop guessing Euler flips

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ section > .wrap{position:relative;z-index:1;}
 .deco-stamp rect{fill:none;stroke:var(--terra);stroke-width:2.4;}
 .deco-stamp .st-t{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:1.6px;fill:var(--terra);}
 .deco-stamp .st-n{font-family:var(--mono);font-size:19px;font-weight:700;letter-spacing:.6px;fill:var(--terra);}
-.deco-ps{display:block;width:120px;height:30px;opacity:.5;pointer-events:none;margin:4px 0 0 2px;}
+.deco-ps{display:block;width:120px;height:30px;opacity:.5;pointer-events:none;margin:4px 0 24px 2px;}
 .collection-head-row{display:grid;grid-template-columns:auto 1fr;align-items:center;gap:20px;margin-bottom:36px;}
 .collection-controller{position:relative;width:400px;height:400px;flex:none;cursor:grab;touch-action:none;}
 .collection-controller:active{cursor:grabbing;}
@@ -1308,10 +1308,8 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
   if (!wrap || !canvasEl || typeof THREE === 'undefined') return;
 
   var section = document.getElementById('collection');
-  // negated from the earlier value: flipping the model upright (below) mirrors
-  // which yaw angle reads as "buttons on the left", so the sign has to flip too
-  var baseRotY = 1.05 - Math.PI;
   var scene, camera, renderer, pad;
+  var baseQuat = new THREE.Quaternion();
 
   try {
     scene = new THREE.Scene();
@@ -1343,20 +1341,22 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
       box.getSize(size);
       box.getCenter(center);
       model.position.sub(center);
-      model.rotation.x = Math.PI; // the raw model sits upside down at rest
       pad.add(model);
-      pad.rotation.y = baseRotY;
+
+      // resting pose: a bit of yaw so it's not a flat symmetric front view,
+      // plus a slight left roll for a dynamic "just set down" look. this
+      // replaces two rounds of guessed Euler flips that made it worse each
+      // time - going back to the low, near-eye-level camera angle that was
+      // already confirmed to look right earlier, instead of the steep
+      // top-down angle that needed those guesses in the first place
+      var yawQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), -0.35);
+      var rollQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), -8 * Math.PI / 180);
+      baseQuat.multiplyQuaternions(rollQ, yawQ);
+      pad.quaternion.copy(baseQuat);
 
       var maxDim = Math.max(size.x, size.y, size.z);
-      // generous margin: the base yaw plus the scroll swing plus manual
-      // drag can all present a wider diagonal silhouette than the
-      // axis-aligned bounding box, so a tight fit crops it at the extremes
-      var dist = maxDim * 3.6;
-      // steep-ish elevation - reads like it's resting on a surface, viewed
-      // from above, but still angled enough to see the button relief
-      // (the first pass was ~5° off horizontal, basically edge-on)
-      var elevation = 46 * Math.PI / 180;
-      camera.position.set(0, dist * Math.sin(elevation), dist * Math.cos(elevation));
+      var dist = maxDim * 2.8;
+      camera.position.set(0, maxDim * 0.5, dist);
       camera.lookAt(0, 0, 0);
       camera.near = dist / 100;
       camera.far = dist * 20;
@@ -1380,38 +1380,43 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
   }
   addEventListener('resize', resize);
 
-  /* drag to spin it yourself - horizontal drag turns it (Y), vertical drag
-     rolls it (Z), like spinning a coin on a table. scroll position sets a
-     slow base swing on Y when you're not actively holding it */
-  var dragging = false, lastX = 0, lastY = 0, dragOffsetY = 0, dragOffsetZ = 0;
+  /* free trackball drag: each move rotates the object around whatever axis
+     is perpendicular to the drag direction (in camera space), the same
+     technique real 3D viewers use - drag any direction and it tumbles that
+     way, not locked to a fixed pair of axes */
+  var dragging = false, lastX = 0, lastY = 0;
+  var dragQuat = new THREE.Quaternion();
   wrap.addEventListener('pointerdown', function (e) {
     dragging = true; lastX = e.clientX; lastY = e.clientY; wrap.setPointerCapture(e.pointerId);
   });
   wrap.addEventListener('pointerup', function () { dragging = false; });
   wrap.addEventListener('pointercancel', function () { dragging = false; });
   wrap.addEventListener('pointermove', function (e) {
-    if (!dragging) return;
-    dragOffsetY += (e.clientX - lastX) * 0.012;
-    dragOffsetZ += (e.clientY - lastY) * 0.012;
-    lastX = e.clientX;
-    lastY = e.clientY;
+    if (!dragging || !camera) return;
+    var dx = e.clientX - lastX, dy = e.clientY - lastY;
+    lastX = e.clientX; lastY = e.clientY;
+    var angle = Math.sqrt(dx * dx + dy * dy) * 0.006;
+    if (angle < 0.0001) return;
+    var axisCam = new THREE.Vector3(-dy, -dx, 0).normalize();
+    var axisWorld = axisCam.applyQuaternion(camera.quaternion);
+    var delta = new THREE.Quaternion().setFromAxisAngle(axisWorld, angle);
+    dragQuat.premultiply(delta);
   });
 
-  /* slow, scroll-tied turn: as the section drifts through the viewport,
-     the controller eases further round from its base angle and back -
-     dragging adds on top of that instead of fighting it */
+  /* slow, scroll-tied turn layered on top when you're not actively
+     dragging, so it's never fully inert even before you touch it */
   function tick(){
     if (pad) {
-      var scrollSwing = 0;
-      if (!prefersReducedMotion && section) {
+      var q = baseQuat.clone().premultiply(dragQuat);
+      if (!prefersReducedMotion && section && !dragging) {
         var rect = section.getBoundingClientRect();
         var vh = innerHeight || document.documentElement.clientHeight;
         var progress = (vh / 2 - (rect.top + rect.height / 2)) / (vh / 2 + rect.height / 2);
         progress = Math.max(-1, Math.min(1, progress));
-        scrollSwing = progress * 0.3;
+        var scrollQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), progress * 0.25);
+        q.premultiply(scrollQ);
       }
-      pad.rotation.y = baseRotY + scrollSwing + dragOffsetY;
-      pad.rotation.z = dragOffsetZ;
+      pad.quaternion.copy(q);
     }
     renderer.render(scene, camera);
     requestAnimationFrame(tick);


### PR DESCRIPTION
follow-up to #60.

two rounds of guessed rotation flips made it worse each time (ended up looking like a floating rocket). stopped guessing - reverted to the low camera angle that was already confirmed working earlier, no flip needed there.

replaced the fixed Y/Z Euler drag with quaternion trackball rotation (drag rotates around whatever axis is perpendicular to the drag direction - same technique real 3D viewers use). free rotation on all axes now, should feel natural instead of fighting a fixed axis pair.

also gave the PS-glyph more bottom margin before the marquee starts.