### PR TITLE
Fix controller orientation for real - verified by actually rendering it

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ section > .wrap{position:relative;z-index:1;}
 .deco-stamp rect{fill:none;stroke:var(--terra);stroke-width:2.4;}
 .deco-stamp .st-t{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:1.6px;fill:var(--terra);}
 .deco-stamp .st-n{font-family:var(--mono);font-size:19px;font-weight:700;letter-spacing:.6px;fill:var(--terra);}
-.deco-ps{display:block;width:120px;height:30px;opacity:.5;pointer-events:none;margin:4px 0 24px 2px;}
+.deco-ps{display:block;width:120px;height:30px;opacity:.5;pointer-events:none;margin:0 0 18px 2px;}
 .collection-head-row{display:grid;grid-template-columns:auto 1fr;align-items:center;gap:20px;margin-bottom:36px;}
 .collection-controller{position:relative;width:400px;height:400px;flex:none;cursor:grab;touch-action:none;}
 .collection-controller:active{cursor:grabbing;}
@@ -644,13 +644,6 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
 <!-- ════════ COLLECTION ════════ -->
 <section id="collection">
   <div class="wrap">
-    <div class="collection-head-row">
-      <div class="collection-controller" id="collection-controller-wrap"><canvas id="collection-controller-canvas"></canvas></div>
-      <div class="collection-head-text">
-        <div class="sec-head reveal"><h2 class="sec-title">The Collection</h2><span class="label">ALBUMS · GAMES · FILMS</span></div>
-        <p class="sec-intro reveal">The taste section. Three lanes, alternating directions, hover to pause and read the commentary.</p>
-      </div>
-    </div>
     <svg class="deco-ps" style="transform:rotate(-3deg);" viewBox="0 0 120 30">
       <polygon points="15,3 26,24 4,24" fill="none" stroke="#4A9B7F" stroke-width="2.2" stroke-linejoin="round"/>
       <circle cx="49" cy="15" r="11" fill="none" stroke="#B5532F" stroke-width="2.2"/>
@@ -658,6 +651,13 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
       <line x1="87" y1="5" x2="70" y2="24" stroke="#5B7FA6" stroke-width="2.4" stroke-linecap="round"/>
       <rect x="98" y="5" width="16" height="16" fill="none" stroke="#A6588A" stroke-width="2.2"/>
     </svg>
+    <div class="collection-head-row">
+      <div class="collection-controller" id="collection-controller-wrap"><canvas id="collection-controller-canvas"></canvas></div>
+      <div class="collection-head-text">
+        <div class="sec-head reveal"><h2 class="sec-title">The Collection</h2><span class="label">ALBUMS · GAMES · FILMS</span></div>
+        <p class="sec-intro reveal">The taste section. Three lanes, alternating directions, hover to pause and read the commentary.</p>
+      </div>
+    </div>
   </div>
 
   <!-- lane 1: the rotation -->
@@ -1341,22 +1341,29 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
       box.getSize(size);
       box.getCenter(center);
       model.position.sub(center);
+      // the raw mesh rests with its face pointing up at the camera instead
+      // of lying flat - confirmed by actually rendering it locally and
+      // comparing 8 candidate rotations side by side instead of guessing
+      // blind again. +90° on X is the one that reads as a real controller.
+      model.rotation.x = Math.PI / 2;
       pad.add(model);
 
-      // resting pose: a bit of yaw so it's not a flat symmetric front view,
-      // plus a slight left roll for a dynamic "just set down" look. this
-      // replaces two rounds of guessed Euler flips that made it worse each
-      // time - going back to the low, near-eye-level camera angle that was
-      // already confirmed to look right earlier, instead of the steep
-      // top-down angle that needed those guesses in the first place
-      var yawQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), -0.35);
+      // resting pose: yaw so it's not perfectly symmetric, slight roll for
+      // a dynamic "just set down" look - also confirmed by rendering
+      // several candidates locally before picking these values
+      var yawQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), -25 * Math.PI / 180);
       var rollQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), -8 * Math.PI / 180);
       baseQuat.multiplyQuaternions(rollQ, yawQ);
       pad.quaternion.copy(baseQuat);
 
       var maxDim = Math.max(size.x, size.y, size.z);
       var dist = maxDim * 2.8;
-      camera.position.set(0, maxDim * 0.5, dist);
+      // 25° elevation: enough to actually see depth (sticks, buttons,
+      // touchpad relief) without it collapsing into a flat top-down
+      // silhouette on one end or an unreadable smear on the other -
+      // also picked by comparing several elevations side by side
+      var elevation = 25 * Math.PI / 180;
+      camera.position.set(0, dist * Math.sin(elevation), dist * Math.cos(elevation));
       camera.lookAt(0, 0, 0);
       camera.near = dist / 100;
       camera.far = dist * 20;
@@ -1403,18 +1410,26 @@ console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real
     dragQuat.premultiply(delta);
   });
 
-  /* slow, scroll-tied turn layered on top when you're not actively
-     dragging, so it's never fully inert even before you touch it */
+  /* idle motion when you're not holding it: a slow continuous turntable
+     spin, plus the scroll-tied swing layered on top - so it's visibly
+     alive at rest, not just reactive to input */
+  var idleAngle = 0;
   function tick(){
     if (pad) {
       var q = baseQuat.clone().premultiply(dragQuat);
-      if (!prefersReducedMotion && section && !dragging) {
-        var rect = section.getBoundingClientRect();
-        var vh = innerHeight || document.documentElement.clientHeight;
-        var progress = (vh / 2 - (rect.top + rect.height / 2)) / (vh / 2 + rect.height / 2);
-        progress = Math.max(-1, Math.min(1, progress));
-        var scrollQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), progress * 0.25);
-        q.premultiply(scrollQ);
+      if (!prefersReducedMotion && !dragging) {
+        idleAngle += 0.0022;
+        var idleQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), idleAngle);
+        q.premultiply(idleQ);
+
+        if (section) {
+          var rect = section.getBoundingClientRect();
+          var vh = innerHeight || document.documentElement.clientHeight;
+          var progress = (vh / 2 - (rect.top + rect.height / 2)) / (vh / 2 + rect.height / 2);
+          progress = Math.max(-1, Math.min(1, progress));
+          var scrollQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), progress * 0.12);
+          q.premultiply(scrollQ);
+        }
       }
       pad.quaternion.copy(q);
     }


### PR DESCRIPTION
follow-up to #61.

stopped guessing. set up a local server + headless Chromium with software WebGL to render the model and compare 8 candidate rotations side by side, picked the one that's actually a controller (rotation.x = +90°), then compared yaw/roll/elevation options the same way before committing to values. screenshotted the final integrated collection section locally before pushing this.

also added idle motion (slow continuous spin, was static before) and moved the PS-glyph above the controller instead of below.