### PR TITLE
Add CTAs throughout the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,9 @@ section{padding:88px 0;}
 .win-links{display:flex;gap:20px;flex-wrap:wrap;font-family:var(--mono);font-size:12px;}
 .win-links a{color:var(--terra);text-decoration:none;border-bottom:1px solid var(--line2);padding-bottom:2px;position:relative;z-index:1;}
 .win-links a:hover{border-color:var(--terra);}
+.sec-cta{margin-top:28px;}
+.sec-cta a{font-family:var(--mono);font-size:13px;color:var(--terra);text-decoration:none;border-bottom:1px solid var(--line2);padding-bottom:2px;transition:border-color .2s;}
+.sec-cta a:hover{border-color:var(--terra);}
 .win-more{color:var(--muted);}
 .work-win.sq .win-pane{padding:22px 26px 20px;}
 .work-win.sq .win-pane h4{font-size:18px;margin-bottom:6px;}
@@ -517,6 +520,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
       <p class="first">Second year at IIT Bhilai, studying Data Science &amp; AI. I got into this field the normal way: built things, broke things, then realised the actual job is keeping things alive <strong>in production</strong>. Now I build AI systems end to end: agents, automations, data pipelines, and the 2am debugging sessions nobody posts about.</p>
       <p>By day I ship client-facing systems at <strong>Altagic</strong>. By night I maintain <strong>diffprompt</strong>, contribute to open source AI tooling, and queue Valorant with the boys. Everything I build gets stress-tested before it ships, because I’d rather break it than let a user do it.</p>
       <p>I lead the AI/ML domain at OpenLake and hold the strong opinion that DSA grind scores tell you almost nothing about whether someone can actually build.</p>
+      <div class="sec-cta"><a href="#work">See what that actually looks like, shipped →</a></div>
     </div>
     <div class="photo-stack reveal d2">
       <div class="polaroid"><img src="img/me-apple.jpg" alt="Rudra at an Apple Store" onerror="this.parentElement.style.display='none'"/><div class="pcap">STRESS-TESTING A MAC PRO I CANNOT AFFORD (YET)</div></div>
@@ -605,6 +609,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
       <div class="win-pane" data-pane="ctxbridge"><div class="win-prompt">$ ctxbridge compress<span class="win-cursor"></span></div><h4>ctxbridge</h4><p>Compress any LLM conversation into one portable context prompt, pick up exactly where you left off in a new session.</p><div class="win-links"><a href="https://github.com/RudraDudhat2509/ctxbridge" target="_blank" rel="noopener">GITHUB ↗</a></div></div>
       <div class="win-pane" data-pane="network"><div class="win-prompt">$ python analyze.py<span class="win-cursor"></span></div><h4>LinkedIn Network Analysis</h4><p>Growth velocity, company concentration, structural leverage from exported connection data. The 1.5L impressions were not an accident.</p><div class="win-links"><a href="https://github.com/RudraDudhat2509/LinkedInNetworkAnalysis" target="_blank" rel="noopener">GITHUB ↗</a></div></div>
     </div>
+    <div class="sec-cta"><a href="#contact">Want something like this built for your product? →</a></div>
   </div>
 </section>
 
@@ -623,6 +628,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
       <div class="xp reveal" data-detail="xp-altagic"><div class="org">Altagic<small>AI Automations Intern</small></div><div class="what">Building production automation systems: agentic workflows, AI-in-the-loop pipelines, internal tooling. Stack: n8n, WhatsApp Business API, Claude, CloseBot. <span class="nda">[ specifics under NDA ]</span></div><div class="when">MAY 2026 → NOW</div></div>
       <div class="xp reveal d1" data-detail="xp-openlake"><div class="org">OpenLake, IIT Bhilai<small>Domain Lead, AI/ML</small></div><div class="what">Leading the AI/ML domain of IIT Bhilai’s open source community. Mentoring builds, reviewing code, recruiting contributors into open source.</div><div class="when">2025 → NOW</div></div>
     </div>
+    <div class="sec-cta"><a href="https://www.linkedin.com/in/rdudhat-iitbhilai/" target="_blank" rel="noopener">Full history on LinkedIn ↗</a></div>
   </div>
 </section>
 


### PR DESCRIPTION
closes #47.

reused the existing label-style link pattern from Lore ("ALL POSTS →") instead of inventing something new - three small text CTAs, not button spam. About->Work, Work->Contact, Experience->LinkedIn (linked out since the resume PDF doesn't exist yet per #52).