### PR TITLE
Curved-TV redesign for the Collection marquee

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,17 +285,14 @@ section{padding:88px 0;}
    The mat + real official poster art does the "premium" work; no dark
    vignette wash needed anymore since posters aren't candid photos that
    need tonal unification. */
-.car-row{overflow:hidden;margin-bottom:32px;
-  mask-image:linear-gradient(to right,transparent 0,#000 4%,#000 96%,transparent 100%);
-  -webkit-mask-image:linear-gradient(to right,transparent 0,#000 4%,#000 96%,transparent 100%);
-}
-.car-track{display:flex;gap:26px;width:max-content;}
+.car-row{overflow:hidden;margin-bottom:32px;perspective:1400px;}
+.car-track{display:flex;gap:26px;width:max-content;transform-style:preserve-3d;}
 /* will-change only while the row is actually on screen (toggled by JS via
    IntersectionObserver below) -- holding it permanently reserves a GPU layer
    for three long-running tracks even while scrolled far out of view. */
 .car-track.in-view{will-change:transform;}
-.ct{position:relative;flex:none;width:260px;background:var(--paper);border:1px solid var(--line2);border-radius:16px;padding:14px 14px 18px;box-shadow:0 14px 34px rgba(40,30,12,.18),0 0 0 0 var(--brass);transition:transform .4s cubic-bezier(.22,1,.36,1),box-shadow .4s;}
-.ct:hover{transform:translateY(-10px) scale(1.02);box-shadow:0 30px 64px rgba(40,30,12,.3),0 0 0 2px var(--brass);z-index:5;}
+.ct{position:relative;flex:none;width:260px;background:var(--paper);border:1px solid var(--line2);border-radius:16px;padding:14px 14px 18px;box-shadow:0 14px 34px rgba(40,30,12,.18),0 0 0 0 var(--brass);transition:box-shadow .4s;will-change:transform;}
+.ct.hot{box-shadow:0 30px 64px rgba(40,30,12,.3),0 0 0 2px var(--brass);z-index:5;}
 .ct-frame{position:relative;width:100%;aspect-ratio:2/3;border-radius:10px;overflow:hidden;background:#18161a;}
 .ct-frame img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .5s ease;}
 .ct:hover .ct-frame img{transform:scale(1.06);}
@@ -661,7 +658,7 @@ footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
       <div class="collection-controller" id="collection-controller-wrap"><canvas id="collection-controller-canvas"></canvas></div>
       <div class="collection-head-text">
         <div class="sec-head reveal"><h2 class="sec-title">The Collection</h2><span class="label">ALBUMS · GAMES · FILMS</span></div>
-        <p class="sec-intro reveal">The taste section. Three lanes, alternating directions, hover to pause and read the commentary.</p>
+        <p class="sec-intro reveal">The taste section. Three lanes, alternating directions, hover a cover to bring it forward and read the commentary.</p>
       </div>
     </div>
   </div>
@@ -840,12 +837,19 @@ if ('IntersectionObserver' in window) {
   document.querySelectorAll('.car-track').forEach((t) => carVisibility.observe(t));
 }
 
-/* ---------- marquee: rAF-driven with velocity easing, so hovering a
-   row glides it to a stop instead of the flat animation-play-state
-   snap a CSS keyframe animation gives you. Per-track speed is derived
-   from its own (already-duplicated) width so the pacing matches what
-   the old keyframes looked like, just smoother in and out of hover. ---------- */
+/* ---------- marquee: rAF-driven, curved-TV arrangement. Cards near the
+   center of the row sit flat facing you; cards toward the edges rotate
+   away in 3D like the row wraps around a curved screen. Drift never
+   slows on hover anymore (that was the previous behavior and it's
+   explicitly not wanted) - hovering a card instead "boosts" just that
+   one card forward and flat, independent of the drift.
+
+   Each card's screen position is computed from arithmetic (index * unit
+   + the track's own scroll offset), never getBoundingClientRect - with
+   ~30 cards across 3 lanes, measuring layout every frame would force a
+   reflow 30+ times per frame and tank scroll performance. ---------- */
 if (!prefersReducedMotion) {
+  const CT_UNIT = 260 + 26; // .ct width + .car-track gap, fixed for every lane
   const marqueeTracks = [
     { id: 'car1', reverse: false, duration: 45 },
     { id: 'car2', reverse: true, duration: 52 },
@@ -854,13 +858,24 @@ if (!prefersReducedMotion) {
     const el = document.getElementById(id);
     if (!el) return null;
     const half = el.scrollWidth / 2;
-    return { el, reverse, half, speed: half / duration, x: reverse ? -half : 0, v: 0, hovered: false };
+    const cards = [...el.children];
+    const row = el.closest('.car-row');
+    return { el, row, rowW: row.clientWidth, cards, boosts: new Array(cards.length).fill(0), hoveredIndex: -1, reverse, half, speed: half / duration, x: reverse ? -half : 0, v: 0 };
   }).filter(Boolean);
 
   marqueeTracks.forEach((t) => {
-    const row = t.el.closest('.car-row');
-    row.addEventListener('mouseenter', () => { t.hovered = true; });
-    row.addEventListener('mouseleave', () => { t.hovered = false; });
+    t.cards.forEach((card, i) => {
+      card.addEventListener('mouseenter', () => { t.hoveredIndex = i; });
+      card.addEventListener('mouseleave', () => { if (t.hoveredIndex === i) t.hoveredIndex = -1; });
+    });
+  });
+
+  // row width only changes on resize, so it's measured there instead of
+  // once per track per frame - same reasoning as avoiding per-card reads
+  let marqueeResizeTimer;
+  addEventListener('resize', () => {
+    clearTimeout(marqueeResizeTimer);
+    marqueeResizeTimer = setTimeout(() => { marqueeTracks.forEach((t) => { t.rowW = t.row.clientWidth; }); }, 150);
   });
 
   let marqueeLast = performance.now();
@@ -868,12 +883,27 @@ if (!prefersReducedMotion) {
     const dt = Math.min(now - marqueeLast, 50) / 1000;
     marqueeLast = now;
     marqueeTracks.forEach((t) => {
-      const target = t.hovered ? 0 : t.speed;
-      t.v += (target - t.v) * Math.min(dt * 3, 1);
+      t.v += (t.speed - t.v) * Math.min(dt * 3, 1);
       t.x += (t.reverse ? 1 : -1) * t.v * dt;
       if (!t.reverse && t.x <= -t.half) t.x += t.half;
       if (t.reverse && t.x >= 0) t.x -= t.half;
       t.el.style.transform = `translate3d(${t.x.toFixed(2)}px,0,0)`;
+
+      const viewportCenter = t.rowW / 2;
+      t.cards.forEach((card, i) => {
+        const centerX = i * CT_UNIT + 130 + t.x;
+        const norm = Math.max(-1, Math.min(1, (centerX - viewportCenter) / (viewportCenter * 0.95)));
+
+        const targetBoost = i === t.hoveredIndex ? 1 : 0;
+        t.boosts[i] += (targetBoost - t.boosts[i]) * 0.15;
+        const b = t.boosts[i];
+
+        const angle = norm * 38 * (1 - b);
+        const z = -Math.abs(norm) * 150 * (1 - b) + b * 60;
+        const scale = (1 - Math.abs(norm) * 0.08) + b * 0.08;
+        card.style.transform = `rotateY(${-angle}deg) translateZ(${z}px) scale(${scale})`;
+        card.classList.toggle('hot', b > 0.4);
+      });
     });
     requestAnimationFrame(marqueeFrame);
   }
@@ -1333,15 +1363,6 @@ document.getElementById('speedrun-btn').addEventListener('click', e => {
   }, SR_STOPS.length * 2400);
 });
 
-/* ---------- carousel tile tilt ---------- */
-document.querySelectorAll('.ct').forEach(c => {
-  c.addEventListener('mousemove', e => {
-    const r = c.getBoundingClientRect();
-    const x = (e.clientX - r.left) / r.width - .5, y = (e.clientY - r.top) / r.height - .5;
-    c.style.transform = `translateY(-6px) scale(1.04) perspective(600px) rotateY(${x*10}deg) rotateX(${-y*8}deg)`;
-  });
-  c.addEventListener('mouseleave', () => c.style.transform = '');
-});
 /* console */
 console.log('%cOi. Inspecting, are we?', 'font-size:18px;font-weight:bold;color:#B5532F;');
 console.log('%cEverything here is hand-built. The PRs are real, the CGPA is real, the samosa take is unfortunately also real.\\n→ github.com/RudraDudhat2509', 'font-size:12px;color:#594E3B;');


### PR DESCRIPTION
closes #68.

replaces the flat scroll with a curved arrangement - center cards flat, edge cards rotate away in 3D. per-card position computed from index*unit + scroll offset, never getBoundingClientRect (avoids a 30+ card reflow every frame). row width measured once at setup + on resize, not per frame.

per explicit direction: no hover-pause anymore (drift never slows, hovering a card boosts just that card forward instead), no edge mask/fade (hard edges). removed the old per-card mousemove tilt handler since it would've fought the new per-frame transform.