### PR TITLE
Sitewide typography swap: Unbounded + Archivo + JetBrains Mono italic

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -8,7 +8,7 @@
 <link rel="icon" type="image/png" sizes="64x64" href="img/monogram-64.png?v=2"/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Hanken+Grotesk:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@200..900&family=Archivo:ital,wght@0,100..900;1,100..900&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet"/>
 <script data-goatcounter="https://rudra.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 <style>
 :root{
@@ -17,8 +17,8 @@
   --ink:#1C1812; --ink2:#594E3B; --muted:#8A7A5C;
   --line:#E2D7BE; --line2:#D4C7A6;
   --terra:#B5532F; --olive:#3F5A36; --brass:#C8922F;
-  --serif:'Fraunces',Georgia,serif;
-  --sans:'Hanken Grotesk',system-ui,sans-serif;
+  --serif:'Unbounded',Georgia,serif;
+  --sans:'Archivo',system-ui,sans-serif;
   --mono:'JetBrains Mono',monospace;
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
@@ -42,7 +42,7 @@ header.page{padding:170px 0 56px;position:relative;overflow:hidden;}
 .deco.blob{background:var(--bg3);opacity:.55;animation:drift 18s ease-in-out infinite;}
 @keyframes drift{0%,100%{transform:translateY(0);}50%{transform:translateY(-26px);}}
 .page h1{font-family:var(--serif);font-weight:430;font-size:clamp(40px,6vw,64px);letter-spacing:-.015em;line-height:1.05;margin-bottom:18px;position:relative;}
-.page h1 em{font-style:italic;color:var(--terra);}
+.page h1 em{font-family:var(--mono);font-style:italic;font-weight:500;color:var(--terra);}
 .page p{font-size:17px;color:var(--ink2);max-width:520px;position:relative;}
 
 .posts{padding:24px 0 110px;}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <link rel="icon" type="image/png" sizes="64x64" href="img/monogram-64.png?v=2"/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Hanken+Grotesk:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500;700&family=Permanent+Marker&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@200..900&family=Archivo:ital,wght@0,100..900;1,100..900&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Permanent+Marker&display=swap" rel="stylesheet"/>
 <script data-goatcounter="https://rudra.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 <style>
 :root{
@@ -17,17 +17,14 @@
   --ink:#1C1812; --ink2:#594E3B; --muted:#8A7A5C;
   --line:#E2D7BE; --line2:#D4C7A6;
   --terra:#B5532F; --olive:#3F5A36; --brass:#C8922F; --slate:#4A5A63;
-  --serif:'Fraunces',Georgia,serif;
-  --sans:'Hanken Grotesk',system-ui,sans-serif;
+  --serif:'Unbounded',Georgia,serif;
+  --sans:'Archivo',system-ui,sans-serif;
   --mono:'JetBrains Mono',monospace;
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 html{scroll-behavior:smooth;}
 body{background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;overflow-x:hidden;font-optical-sizing:auto;font-kerning:normal;font-variant-ligatures:common-ligatures contextual;}
-/* Fraunces carries an opsz 9..144 axis that was already being downloaded and
-   never used. Display sizes take the high end for finer hairlines; small text
-   takes the low end so it stays sturdy. */
-.hero-h1,.sec-title{font-variation-settings:'opsz' 120;text-wrap:balance;}
+.hero-h1,.sec-title{text-wrap:balance;}
 .label,.mono,.status-pill{font-variant-numeric:tabular-nums;}
 /* Stops a single word dangling on the last line of a paragraph. */
 p,blockquote,.mdesc,.sec-intro{text-wrap:pretty;}
@@ -106,7 +103,7 @@ section > .wrap{position:relative;z-index:1;}
 .hero-h1 .ln:nth-child(3)>span{animation-delay:.28s;}
 @keyframes lift{to{transform:none;}}
 .hero-h1 .punct{color:var(--terra);}
-.hero-h1 em{font-style:italic;color:var(--terra);}
+.hero-h1 em{font-family:var(--mono);font-style:italic;font-weight:500;color:var(--terra);}
 .hero-sub{font-size:17.5px;line-height:1.66;color:var(--ink2);max-width:520px;margin-bottom:34px;}
 .hero-sub strong{font-weight:600;border-bottom:2px solid var(--terra);}
 .hero-acts{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
@@ -141,7 +138,7 @@ section > .wrap{position:relative;z-index:1;}
 section{padding:88px 0;}
 .sec-head{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:14px;}
 .sec-title{font-family:var(--serif);font-weight:480;font-size:clamp(30px,4vw,42px);letter-spacing:-.01em;}
-.sec-title em{font-style:italic;font-weight:400;color:var(--muted);font-size:.6em;}
+.sec-title em{font-family:var(--mono);font-style:italic;font-weight:400;color:var(--muted);font-size:.5em;}
 .sec-intro{color:var(--ink2);font-size:16px;max-width:560px;margin-bottom:42px;}
 
 /* ============ ABOUT ============ */
@@ -354,7 +351,7 @@ a.oss-stat:hover{transform:translateY(-3px);box-shadow:0 12px 28px rgba(60,45,20
 footer{background:var(--ink);color:var(--bg);padding:88px 0 40px;}
 .foot-grid{display:flex;flex-wrap:wrap;justify-content:space-between;align-items:flex-start;gap:40px;margin-bottom:64px;}
 .foot-h{font-family:var(--serif);font-weight:430;font-size:clamp(34px,5vw,56px);letter-spacing:-.01em;line-height:1.05;margin-bottom:14px;}
-.foot-h em{font-style:italic;color:var(--brass);}
+.foot-h em{font-family:var(--mono);font-style:italic;font-weight:500;color:var(--brass);}
 .foot-sub{color:rgba(247,241,229,.65);font-size:16px;max-width:440px;margin-bottom:36px;}
 /* inbox rows replace the old inline link list: reads as something you'd
    click INTO, not just a row of underlined text. */

--- a/notes.html
+++ b/notes.html
@@ -8,7 +8,7 @@
 <link rel="icon" type="image/png" sizes="64x64" href="img/monogram-64.png?v=2"/>
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Hanken+Grotesk:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@200..900&family=Archivo:ital,wght@0,100..900;1,100..900&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet"/>
 <script data-goatcounter="https://rudra.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 <style>
 :root{
@@ -17,8 +17,8 @@
   --ink:#1C1812; --ink2:#594E3B; --muted:#8A7A5C;
   --line:#E2D7BE; --line2:#D4C7A6;
   --terra:#B5532F; --olive:#3F5A36; --brass:#C8922F;
-  --serif:'Fraunces',Georgia,serif;
-  --sans:'Hanken Grotesk',system-ui,sans-serif;
+  --serif:'Unbounded',Georgia,serif;
+  --sans:'Archivo',system-ui,sans-serif;
   --mono:'JetBrains Mono',monospace;
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
@@ -42,7 +42,7 @@ header.page{padding:170px 0 50px;position:relative;overflow:hidden;}
 .deco.blob{background:var(--bg3);opacity:.55;animation:drift 18s ease-in-out infinite;}
 @keyframes drift{0%,100%{transform:translateY(0);}50%{transform:translateY(-26px);}}
 .page h1{font-family:var(--serif);font-weight:430;font-size:clamp(40px,6vw,64px);letter-spacing:-.015em;line-height:1.05;margin-bottom:18px;position:relative;}
-.page h1 em{font-style:italic;color:var(--terra);}
+.page h1 em{font-family:var(--mono);font-style:italic;font-weight:500;color:var(--terra);}
 .page p{font-size:17px;color:var(--ink2);max-width:560px;position:relative;}
 .live-pill{display:inline-flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;color:var(--olive);border:1px solid var(--line2);background:var(--paper);border-radius:100px;padding:7px 16px;margin-top:20px;}
 .live-pill .dot{width:7px;height:7px;border-radius:50%;background:var(--olive);animation:blink 2.2s ease-in-out infinite;}


### PR DESCRIPTION
closes #67.

replaces Fraunces + Hanken Grotesk across all three pages (index, blog, notes) - the ID badge already used this stack, everything else was still on the old fonts. em emphasis (the New Yorker's specifically-named 'large italicized serif' cliché) now uses JetBrains Mono italic instead of inheriting the display font's italic.

verified locally before shipping (screenshots of hero + About).